### PR TITLE
fixed comment at jvm.h

### DIFF
--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -539,7 +539,7 @@ JVM_GetNestHost(JNIEnv *env, jclass current);
 JNIEXPORT jobjectArray JNICALL
 JVM_GetNestMembers(JNIEnv *env, jclass current);
 
-/* Sealed types - since JDK 14 */
+/* Sealed types - since JDK 15 */
 JNIEXPORT jobjectArray JNICALL
 JVM_GetPermittedSubtypes(JNIEnv *env, jclass current);
 


### PR DESCRIPTION
just fixing a comment at jvm.h
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/amber pull/16/head:pull/16`
`$ git checkout pull/16`
