### PR TITLE
Attempting to fix separate compilation with sealed classes.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1298,13 +1298,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
          */
         public List<Symbol> permitted;
 
-        /** The class, or interfaces, that are sealed supertypes of this class or interface
-         */
-        public java.util.Set<ClassSymbol> sealedSupers = Set.of();
-
         public boolean isPermittedExplicit = false;
-
-        public boolean hasSealedSuperInSameCU;
 
         public ClassSymbol(long flags, Name name, Type type, Symbol owner) {
             super(TYP, flags, name, type, owner);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5019,13 +5019,13 @@ public class Attr extends JCTree.Visitor {
                 log.error(env.tree, Errors.SealedTypeMustHaveSubtypes);
             }
 
-            if (c.isSealed() && !c.permitted.isEmpty()) {
+            if (c.isSealed()) {
                 Set<Symbol> permittedTypes = new HashSet<>();
                 boolean sealedInUnnamed = c.packge().modle == syms.unnamedModule || c.packge().modle == syms.noModule;
                 for (Symbol subTypeSym : c.permitted) {
                     boolean isTypeVar = false;
                     if (subTypeSym.type.getTag() == TYPEVAR) {
-                        isTypeVar = true;
+                        isTypeVar = true; //error recovery
                         log.error(TreeInfo.declarationFor(subTypeSym, env.tree), Errors.TypeVarListedInPermits);
                     }
                     if (subTypeSym.isAnonymous() && !c.isEnum()) {
@@ -5047,8 +5047,11 @@ public class Attr extends JCTree.Visitor {
                         log.error(TreeInfo.declarationFor(subTypeSym, ((JCClassDecl)env.tree).permitting),
                                 Errors.TypeListedInPermitsIsSameClassOrSupertype(subTypeSym == c.type.tsym ?
                                         Fragments.SameClass : Fragments.Supertype));
-                    } else {
-                        if (!isTypeVar && !((ClassSymbol)subTypeSym).sealedSupers.contains(c.type.tsym)) {
+                    } else if (!isTypeVar) {
+                        boolean thisIsASuper = types.directSupertypes(subTypeSym.type)
+                                                    .stream()
+                                                    .anyMatch(d -> d.tsym == c);
+                        if (!thisIsASuper) {
                             log.error(TreeInfo.declarationFor(subTypeSym, env.tree),
                                     Errors.SubtypeListedInPermitsDoesntExtendSealed(subTypeSym.type, c.type));
                         }
@@ -5056,45 +5059,29 @@ public class Attr extends JCTree.Visitor {
                 }
             }
 
-            if (!c.sealedSupers.isEmpty() && c.isLocal() && !c.isEnum()) {
-                log.error(TreeInfo.declarationFor(c, env.tree), Errors.LocalClassesCantExtendSealed);
-            }
+            List<ClassSymbol> sealedSupers = types.directSupertypes(c.type)
+                                                  .stream()
+                                                  .filter(s -> s.tsym.isSealed())
+                                                  .map(s -> (ClassSymbol) s.tsym)
+                                                  .collect(List.collector());
 
-            if (!c.sealedSupers.isEmpty()) {
-                for (ClassSymbol supertypeSym : c.sealedSupers) {
+            if (sealedSupers.isEmpty()) {
+                if ((c.flags_field & Flags.NON_SEALED) != 0) {
+                    log.error(TreeInfo.declarationFor(c, env.tree), Errors.NonSealedWithNoSealedSupertype);
+                }
+            } else {
+                if (c.isLocal() && !c.isEnum()) {
+                    log.error(TreeInfo.declarationFor(c, env.tree), Errors.LocalClassesCantExtendSealed);
+                }
+
+                for (ClassSymbol supertypeSym : sealedSupers) {
                     if (!supertypeSym.permitted.contains(c.type.tsym)) {
-                        if (supertypeSym.isPermittedExplicit) {
-                            log.error(TreeInfo.declarationFor(c.type.tsym, env.tree), Errors.CantInheritFromSealed(supertypeSym));
-                        }
+                        log.error(TreeInfo.declarationFor(c.type.tsym, env.tree), Errors.CantInheritFromSealed(supertypeSym));
                     }
                 }
                 if (!c.isNonSealed() && !c.isFinal() && !c.isSealed()) {
                     log.error(TreeInfo.declarationFor(c, env.tree), Errors.NonSealedSealedOrFinalExpected);
                 }
-
-                if (!c.hasSealedSuperInSameCU) {
-                    // that supertype most have a permits clause allowing this class to extend it
-                    List<Type> closureOutsideOfSameCU = types.closure(c.type).stream()
-                            .filter(supertype ->
-                                    TreeInfo.declarationFor(supertype.tsym, env.toplevel) == null ||
-                                            TreeInfo.declarationFor(c.outermostClass(), env.toplevel) == null)
-                            .collect(List.collector());
-                    Set<Type> explicitlySealedSuperTypesOutsideOfCU = closureOutsideOfSameCU.stream()
-                            .filter(type -> type != c.type && type.tsym.isSealed()).collect(Collectors.toSet());
-                    for (Type supertype : explicitlySealedSuperTypesOutsideOfCU) {
-                        if (!((ClassSymbol)supertype.tsym).permitted.contains(c.type.tsym)) {
-                            log.error(TreeInfo.declarationFor(c, env.tree), Errors.CantInheritFromSealed(supertype.tsym));
-                        }
-                    }
-
-                    if (!c.isNonSealed() && !c.isFinal() && !c.isSealed()) {
-                        log.error(TreeInfo.declarationFor(c, env.tree), Errors.NonSealedSealedOrFinalExpected);
-                    }
-                }
-            }
-
-            if ((c.flags_field & Flags.NON_SEALED) != 0 && c.sealedSupers.isEmpty()) {
-                log.error(TreeInfo.declarationFor(c, env.tree), Errors.NonSealedWithNoSealedSupertype);
             }
 
             // The info.lint field in the envs stored in typeEnvs is deliberately uninitialized,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -60,6 +60,8 @@ import com.sun.tools.javac.resources.CompilerProperties.Fragments;
 
 import static com.sun.tools.javac.code.TypeTag.*;
 import static com.sun.tools.javac.code.TypeTag.BOT;
+import com.sun.tools.javac.comp.AttrContext;
+import com.sun.tools.javac.comp.Env;
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 
 import com.sun.tools.javac.util.Dependencies.CompletionCause;
@@ -827,105 +829,22 @@ public class TypeEnter implements Completer {
         @Override
         protected void runPhase(Env<AttrContext> env) {
             JCClassDecl tree = env.enclClass;
-            if (tree.sym.type != syms.objectType) {
-                List<Type> directSuperTypes = (types.supertype(tree.sym.type) != null ?
-                        List.of(types.supertype(tree.sym.type)) :
-                        List.nil());
-                directSuperTypes = directSuperTypes.appendList(types.interfaces(tree.sym.type));
-                List<Type> directSuperTypesInSameCU = directSuperTypes.stream()
-                        .filter(supertype ->
-                                TreeInfo.declarationFor(supertype.tsym, env.toplevel) != null &&
-                                        TreeInfo.declarationFor(tree.sym.outermostClass(), env.toplevel) != null)
-                        .collect(List.collector());
-                Set<Type> explicitlySealedSuperTypesInCU = directSuperTypesInSameCU.stream()
-                            .filter(type -> type != tree.sym.type &&
-                                    type.tsym != null &&
-                                    type.tsym.isSealed()).collect(Collectors.toSet());
-
-                boolean anySuperInSameCUIsSealed = !explicitlySealedSuperTypesInCU.isEmpty();
-                if (anySuperInSameCUIsSealed) {
-                    java.util.Set<ClassSymbol> potentiallySealedSuperTypes = superTypeSymsInASealedHierarchy(tree.sym, env, true);
-                    if (!potentiallySealedSuperTypes.isEmpty()) {
-                        for (ClassSymbol supertype : potentiallySealedSuperTypes) {
-                            if (!supertype.permitted.contains(tree.sym.type.tsym)) {
-                                if (!supertype.isPermittedExplicit) {
-                                    if (!tree.sym.isAnonymous() || tree.sym.isEnum()) {
-                                        supertype.permitted = supertype.permitted.append(tree.sym);
-                                        tree.sym.hasSealedSuperInSameCU = true;
-                                    }
-                                }
-                            } else {
-                                tree.sym.hasSealedSuperInSameCU = true;
-                            }
+            if (!tree.sym.isAnonymous() || tree.sym.isEnum()) {
+                for (Type supertype : types.directSupertypes(tree.sym.type)) {
+                    if (supertype.tsym.kind == TYP) {
+                        ClassSymbol supClass = (ClassSymbol) supertype.tsym;
+                        Env<AttrContext> supClassEnv = enter.getEnv(supClass);
+                        if (supClass.isSealed() &&
+                            !supClass.isPermittedExplicit &&
+                            supClassEnv != null &&
+                            supClassEnv.toplevel == env.toplevel) {
+                            supClass.permitted = supClass.permitted.append(tree.sym);
                         }
                     }
                 }
-
-                java.util.Set<ClassSymbol> sealedSuperSyms = superTypeSymsInASealedHierarchy(tree.sym, env, false);
-                boolean hasSuperTypesInSealedHierarchy = !sealedSuperSyms.isEmpty();
-                if (hasSuperTypesInSealedHierarchy) {
-                    tree.sym.sealedSupers = sealedSuperSyms;
-                }
             }
         }
 
-        JCTree findTreeReferringSym(JCClassDecl tree, Symbol sym) {
-            if (tree.extending != null && tree.extending.type.tsym == sym) {
-                return tree.extending;
-            }
-            for (JCExpression implementing: tree.implementing) {
-                if (implementing.type.tsym == sym) {
-                    return implementing;
-                }
-            }
-            return tree;
-        }
-
-        boolean areInSameCU(Symbol sym1, Symbol sym2, Env<AttrContext> env) {
-            return TreeInfo.declarationFor(sym1, env.toplevel) != null &&
-                    TreeInfo.declarationFor(sym2.outermostClass(), env.toplevel) != null;
-        }
-
-        java.util.Set<ClassSymbol> superTypeSymsInASealedHierarchy(ClassSymbol csym, Env<AttrContext> env, boolean inSameCUOnly) {
-            if (csym == null) {
-                return Set.of();
-            }
-
-            Type supertype = csym.type != null ?
-                    types.supertype(csym.type) : null;
-            java.util.Set<ClassSymbol> supertypes = new HashSet<>();
-
-            if (supertype != null &&
-                    supertype.tsym != null &&
-                    supertype != syms.objectType &&
-                    supertype.tsym != null &&
-                    !supertype.tsym.isNonSealed() &&
-                    (inSameCUOnly && areInSameCU(csym, supertype.tsym, env) || !inSameCUOnly)) {
-                supertypes.add((ClassSymbol) supertype.tsym);
-            }
-
-            if (csym.getInterfaces() != null) {
-                for (Type intf : csym.getInterfaces()) {
-                    if (intf != null && intf.tsym != null && intf.tsym != null && !intf.tsym.isNonSealed() &&
-                            (inSameCUOnly && areInSameCU(csym, intf.tsym, env) || !inSameCUOnly)) {
-                        supertypes.add((ClassSymbol) intf.tsym);
-                    }
-                }
-            }
-
-            for (ClassSymbol sup : new ArrayList<>(supertypes)) {
-                if (sup instanceof ClassSymbol) {
-                    java.util.Set<ClassSymbol> supers = superTypeSymsInASealedHierarchy(sup, env, inSameCUOnly);
-                    if ((supers == null || supers.isEmpty()) && !sup.isSealed()) {
-                        supertypes.remove(sup);
-                    }
-                } else {
-                    supertypes.remove(sup);
-                }
-            }
-
-            return supertypes;
-        }
     }
 
     private final class HeaderPhase extends AbstractHeaderPhase {

--- a/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
+++ b/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
@@ -566,4 +566,71 @@ public class SealedDiffConfigurationsTest extends TestRunner {
             throw new AssertionError("Expected output not found. Found: " + error);
         }
     }
+
+    @Test
+    public void testSeparateCompilation(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path src_m = src.resolve("m");
+        tb.writeJavaFiles(src_m,
+                "module m {}",
+                "package pkg.a; public sealed interface Sealed permits pkg.b.Sub {}",
+                "package pkg.b; public final class Sub implements pkg.a.Sealed {}");
+        Path classes = base.resolve("classes");
+        tb.createDirectories(classes);
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics", "--module-source-path",
+                        src.toString(), "--enable-preview",
+                        "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src_m))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics", "--module-source-path",
+                        src.toString(), "--enable-preview", "-doe",
+                        "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src_m.resolve("pkg").resolve("a")))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics", "--module-source-path",
+                        src.toString(), "--enable-preview", "-doe",
+                        "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src_m.resolve("pkg").resolve("b")))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.cleanDirectory(classes);
+
+        //implicit compilations:
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics", "--module-source-path",
+                        src.toString(), "--enable-preview", "-doe",
+                        "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src_m.resolve("pkg").resolve("a")))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        tb.cleanDirectory(classes);
+
+        new JavacTask(tb)
+                .options("-XDrawDiagnostics", "--module-source-path",
+                        src.toString(), "--enable-preview", "-doe",
+                        "-source", Integer.toString(Runtime.version().feature()))
+                .outdir(classes)
+                .files(findJavaFiles(src_m.resolve("pkg").resolve("b")))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+    }
 }


### PR DESCRIPTION
Basically, adjusting the sealed supertype compilation to not depend on TypeEnter.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/amber pull/19/head:pull/19`
`$ git checkout pull/19`
