### PR TITLE
Tweaking templated Strings model.

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/tree/TemplatedStringTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/tree/TemplatedStringTree.java
@@ -44,7 +44,7 @@ public interface TemplatedStringTree extends ExpressionTree {
      *
      * @return original string with placeholders
      */
-    ExpressionTree getString();
+    String getString();
 
     /**
      * Returns list of expressions.

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreeScanner.java
@@ -760,7 +760,9 @@ public class TreeScanner<R,P> implements TreeVisitor<R,P> {
     }
 
     /**
-     * {@inheritDoc} This implementation returns {@code null}.
+     * {@inheritDoc}
+     *
+     * @implSpec This implementation scans the children in left to right order.
      *
      * @param node  {@inheritDoc}
      * @param p  {@inheritDoc}
@@ -768,7 +770,9 @@ public class TreeScanner<R,P> implements TreeVisitor<R,P> {
      */
     @Override
     public R visitTemplatedString(TemplatedStringTree node, P p) {
-        return scan(node.getExpressions(), p);
+        R r = scan(node.getPolicy(), p);
+        r = scanAndReduce(node.getExpressions(), p, r);
+        return r;
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4896,7 +4896,6 @@ public class Attr extends JCTree.Visitor {
         }
 
         Env<AttrContext> localEnv = env.dup(tree, env.info.dup());
-        attribExpr(tree.string, localEnv, syms.stringType);
 
         for (JCExpression arg : tree.expressions) {
             chk.checkNonVoid(arg.pos(), attribExpr(arg, localEnv));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -4101,7 +4101,7 @@ public class Lower extends TreeTranslator {
         int prevPos = make.pos;
         try {
             JCExpression policy = translate(tree.policy);
-            String string = (String)((JCLiteral)tree.string).value;
+            String string = tree.string;
             List<JCExpression> args = translate(tree.expressions);
             List<Type> argTypes = args.stream()
                     .map(arg -> arg.type == syms.botType ? syms.objectType : arg.type)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -669,7 +669,6 @@ public class JavacParser implements Parser {
         if (stringToken.kind == STRINGLITERAL && value.indexOf('\uFFFC') != -1) {
             log.error(DiagnosticFlag.SYNTAX, pos, Errors.UnicodeReplacementCharacter);
         }
-        JCExpression string = F.at(pos).Literal(TypeTag.CLASS, value);
         nextToken();
         token = S.token();
         List<JCExpression> expressions = List.nil();
@@ -686,8 +685,8 @@ public class JavacParser implements Parser {
         while (token.pos < endPos && token.kind != DEFAULT) {
             nextToken();
         }
-        JCExpression t = F.at(pos).TemplatedString(policy, string, expressions);
-        storeEnd(t, endPos);
+        JCExpression t = F.at(pos).TemplatedString(policy, value, expressions);
+        S.setPrevToken(stringToken);
         setMode(oldmode);
         return t;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Lexer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Lexer.java
@@ -60,6 +60,11 @@ public interface Lexer {
     Token prevToken();
 
     /**
+     * Sets the previous token.
+     */
+    void setPrevToken(Token prevToken);
+
+    /**
      * Splits the current token in two and return the first (split) token.
      * For instance {@literal '<<<'} is split into two tokens
      * {@literal '<'} and {@literal '<<'} respectively,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Scanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Scanner.java
@@ -114,6 +114,10 @@ public class Scanner implements Lexer {
         return prevToken;
     }
 
+    public void setPrevToken(Token prevToken) {
+        this.prevToken = prevToken;
+    }
+
     public void nextToken() {
         prevToken = token;
         if (!savedTokens.isEmpty()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -2411,11 +2411,11 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
      */
     public static class JCTemplatedString extends JCExpression implements TemplatedStringTree {
         public JCExpression policy;
-        public JCExpression string;
+        public String string;
         public List<JCExpression> expressions;
 
         protected JCTemplatedString(JCExpression policy,
-                                    JCExpression string,
+                                    String string,
                                     List<JCExpression> expressions) {
             this.policy = policy;
             this.string = string;
@@ -2428,7 +2428,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         }
 
         @Override
-        public ExpressionTree getString() {
+        public String getString() {
             return string;
         }
 
@@ -3438,7 +3438,7 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         JCIdent Ident(Name idname);
         JCLiteral Literal(TypeTag tag, Object value);
         JCTemplatedString TemplatedString(JCExpression policy,
-                                          JCExpression string,
+                                          String string,
                                           List<JCExpression> expressions);
         JCPrimitiveTypeTree TypeIdent(TypeTag typetag);
         JCArrayTypeTree TypeArray(JCExpression elemtype);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeCopier.java
@@ -286,9 +286,8 @@ public class TreeCopier<P> implements TreeVisitor<JCTree,P> {
     public JCTree visitTemplatedString(TemplatedStringTree node, P p) {
         JCTemplatedString t = (JCTemplatedString) node;
         JCExpression policy = copy(t.policy, p);
-        JCExpression string = copy(t.string, p);
         List<JCExpression> expressions = copy(t.expressions, p);
-        return M.at(t.pos).TemplatedString(policy, string, expressions);
+        return M.at(t.pos).TemplatedString(policy, t.string, expressions);
     }
 
     @DefinedBy(Api.COMPILER_TREE)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -546,6 +546,14 @@ public class TreeInfo {
                 JCGuardPattern node = (JCGuardPattern) tree;
                 return getStartPos(node.patt);
             }
+            case TEMPLATED: {
+                JCTemplatedString node = (JCTemplatedString) tree;
+                if (node.policy == null) {
+                    return node.pos;
+                } else {
+                    return getStartPos(node.policy);
+                }
+            }
             case ERRONEOUS: {
                 JCErroneous node = (JCErroneous)tree;
                 if (node.errs != null && node.errs.nonEmpty()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -538,7 +538,7 @@ public class TreeMaker implements JCTree.Factory {
     }
 
     public JCTemplatedString TemplatedString(JCExpression policy,
-                                             JCExpression string,
+                                             String string,
                                              List<JCExpression> expressions) {
         JCTemplatedString tree = new JCTemplatedString(policy, string, expressions);
         tree.pos = pos;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeTranslator.java
@@ -407,7 +407,6 @@ public class TreeTranslator extends JCTree.Visitor {
 
     public void visitTemplatedString(JCTemplatedString tree) {
         tree.policy = translate(tree.policy);
-        tree.string = translate(tree.string);
         tree.expressions = translate(tree.expressions);
 
         result = tree;

--- a/test/langtools/tools/javac/templatedstring/TreeScannerTest.java
+++ b/test/langtools/tools/javac/templatedstring/TreeScannerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify proper behavior of TreeScanner w.r.t. templated Strings
+ * @modules jdk.compiler
+ */
+
+import java.io.*;
+import java.util.*;
+import javax.tools.*;
+import com.sun.source.tree.*;
+import com.sun.source.util.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class TreeScannerTest {
+    public static void main(String... args) throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        String code = """
+                      public class Test {
+                          private void test(int a) {
+                              String s1 = TEST."p\\{a}s";
+                              String s2 = "p\\{a}s";
+                          }
+                      }
+                      """;
+        JavacTask task = (JavacTask) compiler.getTask(null, null, null, null, null, List.of(new TestJFO(code)));
+        StringBuilder output = new StringBuilder();
+        TreeScanner<Void,Void> checker = new TreeScanner<Void, Void>() {
+            private boolean log;
+
+            @Override
+            public Void visitTemplatedString(TemplatedStringTree node, Void p) {
+                boolean prevLog = log;
+                try {
+                    log = true;
+                    return super.visitTemplatedString(node, p);
+                } finally {
+                    log = prevLog;
+                }
+            }
+
+            @Override
+            public Void scan(Tree tree, Void p) {
+                if (log) {
+                    output.append("(");
+                    output.append(tree != null ? tree.getKind() : "null");
+                    try {
+                        return super.scan(tree, p);
+                    } finally {
+                        output.append(")");
+                    }
+                } else {
+                    return super.scan(tree, p);
+                }
+            }
+
+        };
+
+        checker.scan(task.parse(), null);
+
+        String expected = "(IDENTIFIER)(IDENTIFIER)(null)(IDENTIFIER)";
+        if (!expected.equals(output.toString())) {
+            throw new AssertionError("expected output not found, found: " + output);
+        }
+    }
+
+    private static final class TestJFO extends SimpleJavaFileObject {
+        private final String code;
+
+        public TestJFO(String code) throws URISyntaxException, IOException {
+            super(new URI("mem://Test.java"), Kind.SOURCE);
+            this.code = code;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+            return code;
+        }
+
+    }
+}


### PR DESCRIPTION
I was peeking at the templated `String`s, and there are a few tweaks to the model that might be considered:

 * `TreeScanner` should visit all the children under `TemplatedStringTree`.
 * the start and end positions of a `TemplatedStringTree` are wrong - the start position starts at the position of the String literal (not including the policy), and end position is at the end of the last nested expression, not at the end of the String literal.
 * `TemplatedStringTree` has `getString()` that returns an expression of the (templatized) String literal. While this has certain usefulness (e.g. to detect spans), it is different from how e.g. `MemberSelectTree` work. My proposal is to replace the expression with a simple `String`, which is more similar to `MemberSelectTree`, although I admit this might be somewhat controversial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/amber pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber/pull/77.diff">https://git.openjdk.java.net/amber/pull/77.diff</a>

</details>
