### PR TITLE
Fix deconstruction patterns with unconditional nested type pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -301,8 +301,13 @@ public class TransPatterns extends TreeTranslator {
                     extraTest = makeTypeTest(make.Ident(nestedTemp),
                                              make.Type(nested.type));
                 }
-            } else if (nested.type.isReference()) {
-                extraTest = makeBinary(Tag.NE, make.Ident(nestedTemp), makeNull());
+            }
+            else if (nested.type.isNullOrReference() || nested.type.isPrimitive()) {
+                if(nested instanceof JCDeconstructionPattern) {
+                    extraTest = makeBinary(Tag.NE, make.Ident(nestedTemp), makeNull());
+                }
+                else
+                    extraTest = makeLit(syms.booleanType, 1);
             }
             if (extraTest != null) {
                 extracted = makeBinary(Tag.AND, extraTest, extracted);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -301,7 +301,7 @@ public class TransPatterns extends TreeTranslator {
                     extraTest = makeTypeTest(make.Ident(nestedTemp),
                                              make.Type(nested.type));
                 }
-            } else if (nested.type.isNullOrReference() && nested.hasTag(Tag.DECONSTRUCTIONPATTERN)) {
+            } else if (nested.type.isReference() && nested.hasTag(Tag.DECONSTRUCTIONPATTERN)) {
                 extraTest = makeBinary(Tag.NE, make.Ident(nestedTemp), makeNull());
             }
             if (extraTest != null) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -301,13 +301,8 @@ public class TransPatterns extends TreeTranslator {
                     extraTest = makeTypeTest(make.Ident(nestedTemp),
                                              make.Type(nested.type));
                 }
-            }
-            else if (nested.type.isNullOrReference() || nested.type.isPrimitive()) {
-                if(nested instanceof JCDeconstructionPattern) {
-                    extraTest = makeBinary(Tag.NE, make.Ident(nestedTemp), makeNull());
-                }
-                else
-                    extraTest = makeLit(syms.booleanType, 1);
+            } else if (nested.type.isNullOrReference() && nested.hasTag(Tag.DECONSTRUCTIONPATTERN)) {
+                extraTest = makeBinary(Tag.NE, make.Ident(nestedTemp), makeNull());
             }
             if (extraTest != null) {
                 extracted = makeBinary(Tag.AND, extraTest, extracted);

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/Patterns.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/Patterns.java
@@ -209,27 +209,27 @@ public class Patterns {
                               descriptor: ()V
                               flags: (0x0001) ACC_PUBLIC
                                 RuntimeInvisibleTypeAnnotations:
-                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=284, length=11, index=2}
+                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=251, length=11, index=2}
                                     Patterns$DeconstructionPattern$A
-                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=328, length=11, index=3}
+                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=290, length=11, index=3}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
-                                  2: #_A_(): LOCAL_VARIABLE, {start_pc=30, length=11, index=1}
+                                  2: #_A_(): LOCAL_VARIABLE, {start_pc=26, length=11, index=1}
                                     Patterns$DeconstructionPattern$A
-                                  3: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=71, length=11, index=1}
+                                  3: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=63, length=11, index=1}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
-                                  4: #_A_(): LOCAL_VARIABLE, {start_pc=114, length=11, index=2}
+                                  4: #_A_(): LOCAL_VARIABLE, {start_pc=101, length=11, index=2}
                                     Patterns$DeconstructionPattern$A
-                                  5: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=158, length=11, index=3}
+                                  5: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=140, length=11, index=3}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
-                                  6: #_A_(): LOCAL_VARIABLE, {start_pc=199, length=11, index=2}
+                                  6: #_A_(): LOCAL_VARIABLE, {start_pc=176, length=11, index=2}
                                     Patterns$DeconstructionPattern$A
-                                  7: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=243, length=11, index=3}
+                                  7: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=215, length=11, index=3}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
@@ -238,9 +238,9 @@ public class Patterns {
                               descriptor: ()V
                               flags: (0x0000)
                                 RuntimeInvisibleTypeAnnotations:
-                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=28, length=11, index=2}
+                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=23, length=11, index=2}
                                     Patterns$DeconstructionPattern$A
-                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=72, length=11, index=3}
+                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=62, length=11, index=3}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
@@ -253,15 +253,15 @@ public class Patterns {
                               descriptor: ()V
                               flags: (0x0008) ACC_STATIC
                                 RuntimeInvisibleTypeAnnotations:
-                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=30, length=11, index=0}
+                                  0: #_A_(): LOCAL_VARIABLE, {start_pc=26, length=11, index=0}
                                     Patterns$DeconstructionPattern$A
-                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=70, length=11, index=0}
+                                  1: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=62, length=11, index=0}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )
-                                  2: #_A_(): LOCAL_VARIABLE, {start_pc=110, length=11, index=1}
+                                  2: #_A_(): LOCAL_VARIABLE, {start_pc=98, length=11, index=1}
                                     Patterns$DeconstructionPattern$A
-                                  3: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=151, length=11, index=2}
+                                  3: #_CA_(#_value_=[@#_A_(),@#_A_()]): LOCAL_VARIABLE, {start_pc=134, length=11, index=2}
                                     Patterns$DeconstructionPattern$CA(
                                       value=[@Patterns$DeconstructionPattern$A,@Patterns$DeconstructionPattern$A]
                                     )

--- a/test/langtools/tools/javac/patterns/NullSwitch.java
+++ b/test/langtools/tools/javac/patterns/NullSwitch.java
@@ -66,6 +66,28 @@ public class NullSwitch {
         assertEquals(0, matchingSwitch13(""));
         assertEquals(1, matchingSwitch13(0.0));
         assertEquals(2, matchingSwitch13(null));
+
+        // record classes and null
+        assertEquals(1, matchingSwitch14(new R(null)));
+        assertEquals(2, matchingSwitch15(new R(null)));
+    }
+
+    class Super {}
+    class Sub extends Super {}
+    record R(Super s) {}
+
+    private int matchingSwitch14(R r) {
+        return switch(r) {
+            case R(Super s) -> 1;
+            default -> 2;
+        };
+    }
+
+    private int matchingSwitch15(R r) {
+        return switch(r) {
+            case R(Sub s) -> 1;
+            default -> 2;
+        };
     }
 
     private int matchingSwitch1(Object obj) {

--- a/test/langtools/tools/javac/patterns/NullsInDeconstructionPatterns.java
+++ b/test/langtools/tools/javac/patterns/NullsInDeconstructionPatterns.java
@@ -1,0 +1,36 @@
+/*
+ * @test /nodynamiccopyright/
+ * @summary Testing record patterns against the null constant (14.30.2 Pattern Matching)
+ * @compile --enable-preview -source ${jdk.version} NullsInDeconstructionPatterns.java
+ * @run main/othervm --enable-preview NullsInDeconstructionPatterns
+ */
+
+public class NullsInDeconstructionPatterns {
+
+    class Super {}
+    class Sub extends Super {}
+    record R(Super s) {}
+
+    public static void main(String[] args) {
+
+        R r = new R(null);
+
+        if (r instanceof R(Super s1)) {
+            System.out.println("R(Super s1) is resolved to the R(any pattern) and does match");
+        } else {
+            throw new AssertionError("broken");
+        }
+
+        if (r instanceof R(Object o)) {
+            System.out.println("R(Object) is resolved to the R(any pattern) and does match");
+        } else {
+            throw new AssertionError("broken");
+        }
+
+        if (r instanceof R(Sub s2)) {
+            throw new AssertionError("broken");
+        } else {
+            System.out.println("R(Sub s2) is resolved to the pattern R(Sub s) and does not match");
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/NullsInDeconstructionPatterns.out
+++ b/test/langtools/tools/javac/patterns/NullsInDeconstructionPatterns.out
@@ -1,0 +1,3 @@
+NullsInPatterns.java:12:18: compiler.err.instanceof.pattern.no.subtype: compiler.misc.type.null, java.util.List
+NullsInPatterns.java:23:18: compiler.err.instanceof.pattern.no.subtype: compiler.misc.type.null, java.util.List<?>
+2 errors

--- a/test/langtools/tools/javac/patterns/SimpleDeconstructionPattern.java
+++ b/test/langtools/tools/javac/patterns/SimpleDeconstructionPattern.java
@@ -76,19 +76,16 @@ public class SimpleDeconstructionPattern {
         if (testA(new P6(null))) {
             throw new IllegalStateException();
         }
-        if (testA(new P6(new P3(null)))) {
+        if (!testA(new P6(new P3(null)))) {
             throw new IllegalStateException();
         }
         if (testB(new P6(null))) {
             throw new IllegalStateException();
         }
-        if (testB(new P6(new P3(null)))) {
+        if (!testB(new P6(new P3(null)))) {
             throw new IllegalStateException();
         }
         if (testC(new P6(null))) {
-            throw new IllegalStateException();
-        }
-        if (testC(new P6(new P3(null)))) {
             throw new IllegalStateException();
         }
         if (!testC(new P6(new P3("")))) {
@@ -97,10 +94,13 @@ public class SimpleDeconstructionPattern {
         if (!testD(new P4("test"))) {
             throw new IllegalStateException();
         }
-        if (!testE(new P7(0, (short) 0))) {
+        if (!testE(new P6(new P3(null)))) {
             throw new IllegalStateException();
         }
-        if (testE(new P7(0, (short) 1))) {
+        if (!testF(new P7(0, (short) 0))) {
+            throw new IllegalStateException();
+        }
+        if (testF(new P7(0, (short) 1))) {
             throw new IllegalStateException();
         }
         if (!testGen1(new GenRecord1<>(1L, ""))) {
@@ -185,6 +185,10 @@ public class SimpleDeconstructionPattern {
     }
 
     private static boolean testE(Object o) throws Throwable {
+        return o instanceof P6(P3(String s)) && s == null;
+    }
+
+    private static boolean testF(Object o) throws Throwable {
         return o instanceof P7(int i, short s) && i == s;
     }
 


### PR DESCRIPTION
According to the spec:

```
class Super {}
class Sub extends Super {}
record R(Super s) {}

public static void testRes(R r) {
    switch(r) {
       case R(Super s) -> System.out.println("a");
    }
}

testRes(new R(null)); // this should match since after resolution, the nested type pattern is transformed to an any pattern
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.java.net/amber pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber/pull/81.diff">https://git.openjdk.java.net/amber/pull/81.diff</a>

</details>
