### PR TITLE
Fix NPE and exhaustivity bug in record patterns with nested primitive type patterns

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4155,7 +4155,10 @@ public class Attr extends JCTree.Visitor {
             chk.basicHandler.report(pos,
                     diags.fragment(Fragments.InconvertibleTypes(exprType, pattType)));
             return false;
-        } else if (exprType.isPrimitive() ^ pattType.isPrimitive()) {
+        } else if ((exprType.isPrimitive() || pattType.isPrimitive()) &&
+                   (!exprType.isPrimitive() ||
+                    !pattType.isPrimitive() ||
+                    !types.isSameType(exprType, pattType))) {
             chk.basicHandler.report(pos,
                     diags.fragment(Fragments.NotApplicableTypes(exprType, pattType)));
             return false;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -809,9 +809,12 @@ public class Flow {
                     }
                 }
                 for (Symbol currentType : nestedCovered) {
-                    if ((currentType.type.isPrimitive() && currentType.type.equals(currentPatternType.type)) ||
-                            types.isSubtype(currentType.erasure(types), currentPatternType.erasure(types))) {
-                        componentType2Patterns.put(currentType, componentType2Patterns.getOrDefault(currentType, List.nil()).prepend(subTypeCandidate));
+                    if (types.isSubtype(types.erasure(currentType.type),
+                                        types.erasure(currentPatternType.type))) {
+                        componentType2Patterns.put(currentType,
+                                                   componentType2Patterns.getOrDefault(currentType,
+                                                                                       List.nil())
+                                              .prepend(subTypeCandidate));
                     }
                 }
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -809,7 +809,8 @@ public class Flow {
                     }
                 }
                 for (Symbol currentType : nestedCovered) {
-                    if (types.isSubtype(currentType.erasure(types), currentPatternType.erasure(types))) {
+                    if ((currentType.type.isPrimitive() && currentType.type.equals(currentPatternType.type)) ||
+                            types.isSubtype(currentType.erasure(types), currentPatternType.erasure(types))) {
                         componentType2Patterns.put(currentType, componentType2Patterns.getOrDefault(currentType, List.nil()).prepend(subTypeCandidate));
                     }
                 }
@@ -892,7 +893,9 @@ public class Flow {
                     yield covered.contains(seltype.tsym);
                 }
                 case TYPEVAR -> isExhaustive(pos, ((TypeVar) seltype).getUpperBound(), covered);
-                default -> false;
+                default -> {
+                    yield covered.contains(seltype.tsym);
+                }
             };
         }
 

--- a/test/langtools/tools/javac/patterns/DeconstructionPatternErrors.java
+++ b/test/langtools/tools/javac/patterns/DeconstructionPatternErrors.java
@@ -28,6 +28,13 @@ public class DeconstructionPatternErrors {
         if (p instanceof GenRecord<String>(Integer v)); //inconsistency in types
         if (p instanceof P2(var v, var v) v); //duplicated variables
         if (p instanceof P6(P2(var v1, var v2) v1, P2(var v1, var v2) v2) v1); //duplicated variables
+        if (p instanceof P7(byte b)); //incorrect pattern type
+        if (p instanceof P7(long l)); //incorrect pattern type
+        switch (p) {
+            case P7(byte b) -> {} //incorrect pattern type - no exception should occur
+            case P7(long l) -> {} //incorrect pattern type - no exception should occur
+            default -> {}
+        }
     }
 
     public record P(int i) {
@@ -38,6 +45,7 @@ public class DeconstructionPatternErrors {
     public record P4(Object o) {}
     public record P5(String s) {}
     public record P6(Object o1, Object o2) {}
+    public record P7(int i) {}
     public record GenRecord<T>(T s) {}
 
 }

--- a/test/langtools/tools/javac/patterns/DeconstructionPatternErrors.out
+++ b/test/langtools/tools/javac/patterns/DeconstructionPatternErrors.out
@@ -22,6 +22,10 @@ DeconstructionPatternErrors.java:30:59: compiler.err.already.defined: kindname.v
 DeconstructionPatternErrors.java:30:67: compiler.err.already.defined: kindname.variable, v2, kindname.method, main(java.lang.String...)
 DeconstructionPatternErrors.java:30:71: compiler.err.match.binding.exists
 DeconstructionPatternErrors.java:30:75: compiler.err.match.binding.exists
+DeconstructionPatternErrors.java:31:29: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, byte)
+DeconstructionPatternErrors.java:32:29: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, long)
+DeconstructionPatternErrors.java:34:21: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, byte)
+DeconstructionPatternErrors.java:35:21: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, long)
 - compiler.note.preview.filename: DeconstructionPatternErrors.java, DEFAULT
 - compiler.note.preview.recompile
-24 errors
+28 errors

--- a/test/langtools/tools/javac/patterns/NestedPrimitiveDeconstructionPattern.java
+++ b/test/langtools/tools/javac/patterns/NestedPrimitiveDeconstructionPattern.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @compile --enable-preview -source ${jdk.version} NestedPrimitiveDeconstructionPattern.java
+ * @run main/othervm --enable-preview NestedPrimitiveDeconstructionPattern
+ */
+
+import java.util.Objects;
+
+public class NestedPrimitiveDeconstructionPattern {
+
+    public static void main(String... args) throws Throwable {
+        new NestedPrimitiveDeconstructionPattern().doTestR();
+    }
+
+    void doTestR() {
+        assertEquals("OK", switchR1(new R(3, 42d)));
+        assertEquals("OK", switchR1_int_double(new R_i(3, 42d)));
+    }
+
+    record R(Integer x, Double y) {}
+
+    String switchR1(R r) {
+        return switch (r) {
+            case R(Integer x, Double y) -> "OK";
+        };
+    }
+
+    record R_i(int x, double y) {}
+
+    String switchR1_int_double(R_i r) {
+        return switch (r) {
+            case R_i(int x, double y) -> "OK";
+        };
+    }
+
+    private void assertEquals(String expected, String actual) {
+        if (!Objects.equals(expected, actual)) {
+            throw new AssertionError("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+}


### PR DESCRIPTION
The following attempts to address two problems:

a) the crash should not happen (shown below)
b) the switch should be considered exhaustive (as in the equivalent with Integer)

```
public record R(int x) {}

public int test2(R r) {
    return switch (r) {
        case R(int x) -> 1; // crash while type-checking this in Flow
        // error: the switch expression does not cover all possible input values
    };
}
```

<details>
<summary>Stack trace</summary>

```java
java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Type.isPrimitive()" because "t" is null
        at jdk.compiler/com.sun.tools.javac.code.Types.eraseNotNeeded(Types.java:2394)
        at jdk.compiler/com.sun.tools.javac.code.Types.erasure(Types.java:2387)
        at jdk.compiler/com.sun.tools.javac.code.Symbol$ClassSymbol.erasure(Symbol.java:1354)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.coversDeconstructionStartingFromComponent(Flow.java:812)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.coveredSymbols(Flow.java:776)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.coveredSymbolsForCases(Flow.java:745)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitSwitchExpression(Flow.java:728)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCSwitchExpression.accept(JCTree.java:1385)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:447)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitReturn(Flow.java:977)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCReturn.accept(JCTree.java:1714)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:447)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.scanStat(Flow.java:507)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.scanStats(Flow.java:515)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitBlock(Flow.java:607)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1092)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:447)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.scanStat(Flow.java:507)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitMethodDef(Flow.java:571)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:922)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:447)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.visitClassDef(Flow.java:551)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:820)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$BaseAnalyzer.scan(Flow.java:447)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.analyzeTree(Flow.java:1039)
        at jdk.compiler/com.sun.tools.javac.comp.Flow$AliveAnalyzer.analyzeTree(Flow.java:1031)
        at jdk.compiler/com.sun.tools.javac.comp.Flow.analyzeTree(Flow.java:223)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1377)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1351)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:946)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:317)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:176)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)

```
</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.java.net/amber pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber/pull/82.diff">https://git.openjdk.java.net/amber/pull/82.diff</a>

</details>
