### PR TITLE
Fix parse error with nested record classes and empty record component list

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -788,7 +788,7 @@ public class JavacParser implements Parser {
             }
             if (token.kind == LPAREN) {
                 ListBuffer<JCPattern> nested = new ListBuffer<>();
-                if (S.token(1).kind != RPAREN) {
+                if (!peekToken(RPAREN)) {
                     do {
                         nextToken();
                         JCPattern nestedPattern = parsePattern(token.pos, null, null);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -788,11 +788,15 @@ public class JavacParser implements Parser {
             }
             if (token.kind == LPAREN) {
                 ListBuffer<JCPattern> nested = new ListBuffer<>();
-                do {
+                if (S.token(1).kind != RPAREN) {
+                    do {
+                        nextToken();
+                        JCPattern nestedPattern = parsePattern(token.pos, null, null);
+                        nested.append(nestedPattern);
+                    } while (token.kind == COMMA);
+                } else {
                     nextToken();
-                    JCPattern nestedPattern = parsePattern(token.pos, null, null);
-                    nested.append(nestedPattern);
-                } while (token.kind == COMMA);
+                }
                 accept(RPAREN);
                 JCVariableDecl var;
                 if (token.kind == IDENTIFIER) {
@@ -3175,7 +3179,11 @@ public class JavacParser implements Parser {
                     } else {
                         return PatternResult.EXPRESSION;
                     }
-                case LPAREN: parentDepth++; break;
+                case LPAREN:
+                    if (S.token(lookahead + 1).kind == RPAREN) {
+                        return PatternResult.PATTERN;
+                    }
+                    parentDepth++; break;
                 case RPAREN: parentDepth--; break;
                 case ARROW: return parentDepth > 0 ? PatternResult.EXPRESSION
                                                    : pendingResult;

--- a/test/langtools/tools/javac/patterns/EmptyRecordClass.java
+++ b/test/langtools/tools/javac/patterns/EmptyRecordClass.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @compile --enable-preview -source ${jdk.version} EmptyRecordClass.java
+ */
+
+public class EmptyRecordClass {
+    record X() {}
+
+    void test(X w) {
+        switch (w) {
+            case X(): break;
+        }
+    }
+
+
+    sealed interface W permits W.X1 {
+        record X1() implements W {}
+    }
+
+    public int test2(W w) {
+        return switch (w) {
+            case W.X1() -> 1;
+        };
+    }
+}


### PR DESCRIPTION
This PR addresses the following parse error.

The following snippet of code:

```java
    interface W {
        record X1() implements W {}
    }

    public int test(W w) {
        return switch (w) {
            case W.X1() -> 1;
        };
    }
```

reports that it cannot find symbol.

```
error: cannot find symbol
            case W.X1() -> 1;
                  ^
  symbol:   method X1()
  location: interface W
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/amber pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.java.net/amber pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/amber/pull/83.diff">https://git.openjdk.java.net/amber/pull/83.diff</a>

</details>
