### PR TITLE
fixed default locale in FormatterBuilder test

### DIFF
--- a/src/java.base/share/classes/java/util/FormatItem.java
+++ b/src/java.base/share/classes/java/util/FormatItem.java
@@ -150,7 +150,7 @@ class FormatItem {
             this.groupSize = groupSize;
             this.value = value;
             this.parentheses = parentheses && isNegative;
-            this.prefixSign = (byte)(isNegative ? (parentheses ? (sign == ' ' ? ' ' : '\0') : minusSign) : sign);
+            this.prefixSign = (byte)(isNegative ? (parentheses ? '\0' : minusSign) : sign);
         }
 
         private int signLength() {

--- a/src/java.base/share/classes/java/util/FormatItem.java
+++ b/src/java.base/share/classes/java/util/FormatItem.java
@@ -131,12 +131,12 @@ class FormatItem {
         private final boolean isNegative;
         private final int width;
         private final byte prefixSign;
-        private final byte suffixSign;
         private final int groupSize;
         private final long value;
+        private final boolean parentheses;
 
         FormatItemDecimal(DecimalFormatSymbols dfs, int width, char sign,
-                          int groupSize, long value) throws Throwable {
+                          boolean parentheses, int groupSize, long value) throws Throwable {
             this.groupingSeparator = dfs.getGroupingSeparator();
             this.zeroDigit = dfs.getZeroDigit();
             this.minusSign = dfs.getMinusSign();
@@ -147,26 +147,14 @@ class FormatItem {
             this.isNegative = value < 0L;
             this.length = this.isNegative ? length - 1 : length;
             this.width = width;
-            this.prefixSign = (byte)prefixSign(sign, isNegative);
-            this.suffixSign = (byte)suffixSign(sign, isNegative);
             this.groupSize = groupSize;
             this.value = value;
-        }
-
-        private char prefixSign(char sign, boolean isNegative) {
-            if (isNegative) {
-                return sign == '(' ? '(' : minusSign;
-            } else {
-                return sign == '+' || sign == ' ' ? sign : '\0';
-            }
-        }
-
-        private char suffixSign(char sign, boolean isNegative) {
-            return isNegative && sign == '(' ? ')' : '\0';
+            this.parentheses = parentheses && isNegative;
+            this.prefixSign = (byte)(isNegative ? (parentheses ? (sign == ' ' ? ' ' : '\0') : minusSign) : sign);
         }
 
         private int signLength() {
-            return (prefixSign != '\0' ? 1 : 0) + (suffixSign != '\0' ? 1 : 0);
+            return (prefixSign != '\0' ? 1 : 0) + (parentheses ? 2 : 0);
         }
 
         private int groupLength() {
@@ -184,8 +172,8 @@ class FormatItem {
         public long prepend(long lengthCoder, byte[] buffer) throws Throwable {
             MethodHandle putCharMH = selectPutChar(lengthCoder);
 
-            if (suffixSign != '\0') {
-                putCharMH.invokeExact(buffer, (int)--lengthCoder, (int)suffixSign);
+            if (parentheses) {
+                putCharMH.invokeExact(buffer, (int)--lengthCoder, (int)')');
             }
 
             if (0 < groupSize) {
@@ -212,6 +200,9 @@ class FormatItem {
                 putCharMH.invokeExact(buffer, (int)--lengthCoder, (int)'0');
             }
 
+            if (parentheses) {
+                putCharMH.invokeExact(buffer, (int)--lengthCoder, (int)'(');
+            }
             if (prefixSign != '\0') {
                 putCharMH.invokeExact(buffer, (int)--lengthCoder, (int)prefixSign);
             }

--- a/src/java.base/share/classes/java/util/FormatItem.java
+++ b/src/java.base/share/classes/java/util/FormatItem.java
@@ -195,7 +195,7 @@ class FormatItem {
                     if (groupIndex-- == 0) {
                         putCharMH.invokeExact(buffer, (int)--lengthCoder,
                                 (int)groupingSeparator);
-                        groupIndex = groupSize;
+                        groupIndex = groupSize - 1;
                     }
 
                     putCharMH.invokeExact(buffer, (int)--lengthCoder,

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -241,8 +241,7 @@ final class FormatterBuilder {
         MethodHandle mh = identity(ptype);
         MethodType mt = mh.type();
 
-        if (ptype == byte.class || ptype == short.class ||
-            ptype == Short.class || ptype == Integer.class) {
+        if (ptype == Integer.class) {
             mt = mt.changeReturnType(int.class);
         } else if (ptype == Long.class) {
             mt = mt.changeReturnType(long.class);

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -241,14 +241,21 @@ final class FormatterBuilder {
         MethodHandle mh = identity(ptype);
         MethodType mt = mh.type();
 
-        if (ptype == Integer.class) {
-            mt = mt.changeReturnType(int.class);
-        } else if (ptype == Long.class) {
-            mt = mt.changeReturnType(long.class);
-        } else if (ptype == float.class || ptype == Float.class ||
-                   ptype == Double.class) {
-            mt = mt.changeReturnType(double.class);
-        }
+//cannot cast to primitive types as it breaks null values formatting
+//        if (ptype == byte.class || ptype == short.class ||
+//            ptype == Byte.class || ptype == Short.class ||
+//            ptype == Integer.class) {
+//            mt = mt.changeReturnType(int.class);
+//        } else if (ptype == Long.class) {
+//            mt = mt.changeReturnType(long.class);
+//        } else if (ptype == float.class || ptype == Float.class ||
+//                   ptype == Double.class) {
+//            mt = mt.changeReturnType(double.class);
+//        } else if (ptype == Boolean.class) {
+//            mt = mt.changeReturnType(boolean.class);
+//        } else if (ptype == Character.class) {
+//            mt = mt.changeReturnType(char.class);
+//        }
 
         Class<?> itype = mt.returnType();
 

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -378,6 +378,13 @@ final class FormatterBuilder {
         }
 
         if (handled) {
+            if (!isPrimitive) {
+                MethodHandle test = NullCheck_MH.asType(
+                        NullCheck_MH.type().changeParameterType(0, ptype));
+                MethodHandle pass = dropArguments(FINull_MH, 0, ptype);
+                mh = guardWithTest(test, pass, mh);
+            }
+
             if (0 < width) {
                 if (isFlag(flags, LEFT_JUSTIFY)) {
                     mh = filterReturnValue(mh,
@@ -386,13 +393,6 @@ final class FormatterBuilder {
                     mh = filterReturnValue(mh,
                             insertArguments(FIFillLeft_MH, 0, width));
                 }
-            }
-
-            if (!isPrimitive) {
-                MethodHandle test = NullCheck_MH.asType(
-                        NullCheck_MH.type().changeParameterType(0, ptype));
-                MethodHandle pass = dropArguments(FINull_MH, 0, ptype);
-                mh = guardWithTest(test, pass, mh);
             }
 
             if (isFlag(flags, UPPERCASE)) {

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -122,8 +122,8 @@ final class FormatterBuilder {
 
     private static final MethodHandle FIDecimal_MH =
             findStringConcatItemConstructor(FormatItemDecimal.class,
-                    DecimalFormatSymbols.class, int.class, char.class, int.class,
-                    long.class);
+                    DecimalFormatSymbols.class, int.class, char.class, boolean.class,
+                    int.class, long.class);
 
     private static final MethodHandle FIHexadecimal_MH =
             findStringConcatItemConstructor(FormatItemHexadecimal.class,
@@ -334,14 +334,14 @@ final class FormatterBuilder {
                                                  PARENTHESES)) {
                         handled = true;
                         int zeroPad = isFlag(flags, ZERO_PAD) ? width : -1;
-                        char sign = isFlag(flags, PARENTHESES)   ? '(' :
-                                    isFlag(flags, PLUS)          ? '+' :
-                                    isFlag(flags, LEADING_SPACE) ? ' ' : '-';
+                        char sign = isFlag(flags, PLUS)          ? '+' :
+                                    isFlag(flags, LEADING_SPACE) ? ' ' : '\0';
+                        boolean parentheses = isFlag(flags, PARENTHESES);
                         int groupSize = isFlag(flags, GROUP) ?
                                 groupSize(locale, dfs) : 0;
                         mh = filterReturnValue(mh,
                                 insertArguments(FIDecimal_MH, 0, dfs, zeroPad,
-                                        sign, groupSize));
+                                        sign, parentheses, groupSize));
                     }
                 }
             }

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -250,8 +250,6 @@ final class FormatterBuilder {
         } else if (ptype == float.class || ptype == Float.class ||
                    ptype == Double.class) {
             mt = mt.changeReturnType(double.class);
-        } else if (ptype == Boolean.class) {
-            mt = mt.changeReturnType(boolean.class);
         } else if (ptype == Character.class) {
             mt = mt.changeReturnType(char.class);
         }
@@ -290,7 +288,7 @@ final class FormatterBuilder {
                     }
                 }
 
-                if (validFlags(flags, LEFT_JUSTIFY | UPPERCASE)) {
+                if (validFlags(flags, LEFT_JUSTIFY | UPPERCASE) && precision == -1) {
                     if (itype == String.class) {
                         handled = true;
                         mh = filterReturnValue(mh, FIString_MH);

--- a/src/java.base/share/classes/java/util/FormatterBuilder.java
+++ b/src/java.base/share/classes/java/util/FormatterBuilder.java
@@ -242,16 +242,13 @@ final class FormatterBuilder {
         MethodType mt = mh.type();
 
         if (ptype == byte.class || ptype == short.class ||
-            ptype == Byte.class || ptype == Short.class ||
-            ptype == Integer.class) {
+            ptype == Short.class || ptype == Integer.class) {
             mt = mt.changeReturnType(int.class);
         } else if (ptype == Long.class) {
             mt = mt.changeReturnType(long.class);
         } else if (ptype == float.class || ptype == Float.class ||
                    ptype == Double.class) {
             mt = mt.changeReturnType(double.class);
-        } else if (ptype == Character.class) {
-            mt = mt.changeReturnType(char.class);
         }
 
         Class<?> itype = mt.returnType();

--- a/src/java.base/share/classes/jdk/internal/util/Digits.java
+++ b/src/java.base/share/classes/jdk/internal/util/Digits.java
@@ -266,7 +266,7 @@ public interface Digits {
             int digits = DIGITS[(int) (value & 0x3F)];
             putCharMH.invokeExact(buffer, --index, digits & 0xFF);
 
-            if (0xF < value) {
+            if (7 < value) {
                 putCharMH.invokeExact(buffer, --index, digits >> 8);
             }
 

--- a/test/jdk/java/lang/template/StringTemplateTest.java
+++ b/test/jdk/java/lang/template/StringTemplateTest.java
@@ -126,7 +126,7 @@ public class StringTemplateTest {
     String randomFormat(Category category) {
         char c;
         return "%" + switch (category) {
-            case GENERAL -> randomWidth("-") + randomPrecision(10, 10) + randomChar("bBhHsS");
+            case GENERAL -> randomWidth("-") + randomPrecision() + randomChar("bBhHsS");
             case CHARACTER -> randomWidth("-") + randomChar("cC");
             case INTEGRAL -> switch (c = randomChar("doxX")) {
                 case 'd' -> randomFlags("+ ,(");
@@ -138,12 +138,12 @@ public class StringTemplateTest {
             } + randomWidth("-0") + c;
             case FLOATING -> switch (c = randomChar("eEfaAgG")) {
                 case 'a', 'A' -> randomFlags("+ ") + randomWidth("-0");
-                case 'e', 'E' -> randomFlags("+ (") + randomWidth("-0") + randomPrecision(0, 10);
-                default -> randomFlags("+ ,(") + randomWidth("-0") + randomPrecision(0, 10);
+                case 'e', 'E' -> randomFlags("+ (") + randomWidth("-0") + randomPrecision();
+                default -> randomFlags("+ ,(") + randomWidth("-0") + randomPrecision();
             } + c;
             case BIG_FLOAT -> switch (c = randomChar("eEfgG")) {
-                case 'e', 'E' -> randomFlags("+ (") + randomWidth("-0") + randomPrecision(0, 10);
-                default -> randomFlags("+ ,(") + randomWidth("-0") + randomPrecision(0, 10);
+                case 'e', 'E' -> randomFlags("+ (") + randomWidth("-0") + randomPrecision();
+                default -> randomFlags("+ ,(") + randomWidth("-0") + randomPrecision();
             } + c;
             case DATE ->  randomWidth("-") + randomChar("tT") + randomChar("BbhAaCYyjmdeRTrDFc");
         };
@@ -163,11 +163,11 @@ public class StringTemplateTest {
 
     String randomWidth(String flags) {
         var f = r.nextInt(flags.length() + 1);
-        return f < flags.length() ? flags.charAt(f) + String.valueOf(r.nextInt(10) + 10) : "";
+        return r.nextBoolean() ? (r.nextBoolean() ? flags.charAt(r.nextInt(flags.length())) : "") + String.valueOf(r.nextInt(10) + 1) : "";
     }
 
-    String randomPrecision(int shift, int range) {
-        return r.nextBoolean() ? '.' + String.valueOf(shift + r.nextInt(range)) : "";
+    String randomPrecision() {
+        return r.nextBoolean() ? '.' + String.valueOf(r.nextInt(10) + 1) : "";
     }
 
     public Class<?> compile() throws Exception {

--- a/test/jdk/java/lang/template/StringTemplateTest.java
+++ b/test/jdk/java/lang/template/StringTemplateTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 0000000
+ * @summary Exercise runtime handing of templated strings.
+ * @enablePreview true
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.*;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+import javax.tools.ToolProvider;
+
+public class StringTemplateTest {
+
+    enum Category{GENERAL, CHARACTER, INTEGRAL, BIG, FLOATING, DATE, PERCENT, LINE};
+
+    static String randomFormat(Category category, Random r) {
+        char c;
+        return "%" + switch (category) {
+            case GENERAL -> randomFlags("-", r) + randomWidth(r) + randomMax(r) + randomConversion("bBhHsS", r);
+            case CHARACTER -> randomFlags("-", r) + randomWidth(r) + randomConversion("cC", r);
+            case INTEGRAL -> switch (c = randomConversion("doxX", r)) {
+                case 'd'-> randomFlags("-+ 0,(", r);
+                default -> randomFlags("-#0", r);
+            } + randomWidth(r) + c;
+            case BIG -> switch (c = randomConversion("doxX", r)) {
+                case 'd' -> randomFlags("-+ 0,(", r);
+                default -> randomFlags("-#+ 0(", r);
+            } + randomWidth(r) + c;
+            case FLOATING -> switch (c = randomConversion("eEfgGaA", r)) {
+                case 'a', 'A' -> randomFlags("-#+ 0", r);
+                case 'g', 'G' -> randomFlags("-#+ 0,(", r) + randomMax(r);
+                default -> randomFlags("-#+ 0,(", r) + randomPrecision(r);
+            } + randomWidth(r) + c;
+            case DATE ->  randomFlags("-", r) + randomWidth(r) + randomConversion("tT", r);
+            case PERCENT ->  randomWidth(r) + '%';
+            case LINE -> 'n';
+        };
+    }
+
+    static String randomFlags(String flags, Random r) {
+        var sb = new StringBuilder(flags.length());
+        for (var f : flags.toCharArray()) {
+            if (r.nextBoolean()) sb.append(f);
+        }
+        return sb.toString();
+    }
+
+    static char randomConversion(String conversions, Random r) {
+        return conversions.charAt(r.nextInt(conversions.length()));
+    }
+
+    static String randomWidth(Random r) {
+        return r.nextBoolean() ? String.valueOf(r.nextInt(10)) : "";
+    }
+
+    static String randomPrecision(Random r) {
+        return r.nextBoolean() ? ',' + String.valueOf(r.nextInt(10)) : "";
+    }
+
+    static String randomMax(Random r) {
+        return r.nextBoolean() ? ',' + String.valueOf(10 + r.nextInt(10)) : "";
+    }
+
+    public static void main(String... args) throws Exception {
+        var r = new Random(1);
+        for (int i = 0; i < 20; i++) {
+            System.out.println(randomFormat(Category.values()[r.nextInt(Category.values().length)], r));
+        }
+        var gen = compile("""
+            public static void run() {
+                var what = "ahoj";
+                var i = 15;
+                System.out.println(FMT."%s\\{what} %4d\\{i}");
+            }
+        """).getMethod("run").invoke(null);
+    }
+
+    public static Class<?> compile(String sourceFragment) throws Exception {
+        var classes = new HashMap<String, byte[]>();
+        var fileManager = new ForwardingJavaFileManager(ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null)) {
+            @Override
+            public ClassLoader getClassLoader(JavaFileManager.Location location) {
+                return new ClassLoader() {
+                    @Override
+                    public Class<?> loadClass(String name) throws ClassNotFoundException {
+                        try {
+                            return super.loadClass(name);
+                        } catch (ClassNotFoundException e) {
+                            byte[] classData = classes.get(name);
+                            return defineClass(name, classData, 0, classData.length);
+                        }
+                    }
+                };
+            }
+            @Override
+            public JavaFileObject getJavaFileForOutput(JavaFileManager.Location location, String name, JavaFileObject.Kind kind, FileObject originatingSource) throws UnsupportedOperationException {
+                return new SimpleJavaFileObject(URI.create(name + ".class"), JavaFileObject.Kind.CLASS) {
+                    @Override
+                    public OutputStream openOutputStream() {
+                        return new FilterOutputStream(new ByteArrayOutputStream()) {
+                            @Override
+                            public void close() throws IOException {
+                                classes.put(name, ((ByteArrayOutputStream)out).toByteArray());
+                            }
+                        };
+                    }
+                };
+            }
+        };
+        if (ToolProvider.getSystemJavaCompiler().getTask(null, fileManager, null,
+                List.of("--enable-preview", "-source", String.valueOf(Runtime.version().feature())), null,
+                List.of(new SimpleJavaFileObject(URI.create("StringTemplateTest$.java"), JavaFileObject.Kind.SOURCE) {
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                return STR."""
+                    public class StringTemplateTest$ {
+                        \{sourceFragment}
+                    }
+                    """;
+            }
+        })).call()) {
+            return fileManager.getClassLoader(CLASS_OUTPUT).loadClass("StringTemplateTest$");
+        } else {
+            throw new AssertionError("compilation failed");
+        }
+    }
+}

--- a/test/jdk/java/lang/template/StringTemplateTest.java
+++ b/test/jdk/java/lang/template/StringTemplateTest.java
@@ -46,13 +46,13 @@ import javax.tools.ToolProvider;
 public class StringTemplateTest {
     enum Category{GENERAL, CHARACTER, INTEGRAL, BIG_INT, FLOATING, BIG_FLOAT, DATE};
 
-    static final String[] GENERAL = {"true", "false", "(Object)null", "STR", "B", "BOOL"};
-    static final String[] CHARS = {"C", "CHAR"};
-    static final String[] INTS = {"L", "LONG", "I", "INT", "S", "SHORT", "Long.MAX_VALUE", "Long.MIN_VALUE"};
+    static final String[] GENERAL = {"true", "false", "(Object)null", "STR", "BO", "BOOL", "(Boolean)null"};
+    static final String[] CHARS = {"C", "CHAR", "(Character)null"};
+    static final String[] INTS = {"L", "LONG", "I", "INT", "S", "SHORT", "BY", "BYTE", "Long.MAX_VALUE", "Long.MIN_VALUE", "(Long)null", "(Integer)null", "(Short)null", "(Byte)null"};
     static final String[] BIGINTS = {};
-    static final String[] FLOATS = {"F", "FLOAT", "D", "DOUBLE", "Double.NEGATIVE_INFINITY", "Double.NaN", "Double.MAX_VALUE"};
+    static final String[] FLOATS = {"F", "FLOAT", "D", "DOUBLE", "Double.NEGATIVE_INFINITY", "Double.NaN", "Double.MAX_VALUE", "(Double)null", "(Float)null"};
     static final String[] BIGFLOATS = {};
-    static final String[] DATES = {"java.util.Calendar.getInstance().getTime()"};
+    static final String[] DATES = {};
 
     final Random r = new Random(1);
 
@@ -244,10 +244,12 @@ public class StringTemplateTest {
                 static Long LONG = 9876543210l;
                 static int I = 42;
                 static Integer INT = -49;
-                static boolean B = true;
-                static Boolean BOOL = null;
+                static boolean BO = true;
+                static Boolean BOOL = false;
                 static short S = 13;
                 static Short SHORT = -17;
+                static byte BY = -3;
+                static Byte BYTE = 12;
                 static float F = 4.789f;
                 static Float FLOAT = -0.000006f;
                 static double D = 6545745.6734654563;
@@ -297,8 +299,8 @@ public class StringTemplateTest {
         var log = new LinkedList<String>();
         new StringTemplateTest().compile().getMethod("run", List.class).invoke(null, log);
         if (!log.isEmpty()) {
-            log.addFirst(STR."failed \{log.size()} tests:");
-            throw new AssertionError(String.join("\n", log));
+            log.forEach(System.out::println);
+            throw new AssertionError(STR."failed \{log.size()} tests");
         }
     }
 }

--- a/test/jdk/java/lang/template/StringTemplateTest.java
+++ b/test/jdk/java/lang/template/StringTemplateTest.java
@@ -221,11 +221,11 @@ public class StringTemplateTest {
     String genSource() {
         var delimiter = "\n        ";
         var fragments = new LinkedList<String>();
-        for (int i = 0; i < 161; i++) {
+        for (int i = 0; i < 1500; i++) {
             var c = Category.values()[r.nextInt(Category.values().length)];
             var format = randomFormat(c);
             var value = randomValue(c);
-            var qValue = value.replace("\"", "\\\"");
+            var qValue = value.replace("\\", "\\\\").replace("\"", "\\\"");
             fragments.add(STR."test(STR.\"\{format}\\{\{value}}\", FMT.\"\{format}\\{\{value}}\", \"\{format}\", \"\{qValue}\", \{value}, log);");
         }
         return STR."""


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/amber pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/amber pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/amber/pull/85.diff">https://git.openjdk.org/amber/pull/85.diff</a>

</details>
