### PR TITLE
added StringTemplateFMT jmh micro benchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/template/StringTemplateFMT.java
+++ b/test/micro/org/openjdk/bench/java/lang/template/StringTemplateFMT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.template;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/*
+ * This benchmark measures StringTemplate.FMT FormatProcessor performance;
+ * exactly mirroring {@link org.openjdk.bench.java.lang.StringFormat} benchmark
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3, jvmArgsAppend = "--enable-preview")
+public class StringTemplateFMT {
+
+    public String s = "str";
+    public int i = 17;
+
+    @Benchmark
+    public String stringFormat() {
+        return FMT."%s\{s}";
+    }
+
+    @Benchmark
+    public String stringIntFormat() {
+        return FMT."%s\{s} %d\{i}";
+    }
+
+    @Benchmark
+    public String widthStringFormat() {
+        return FMT."%3s\{s}";
+    }
+
+    @Benchmark
+    public String widthStringIntFormat() {
+        return FMT."%3s\{s} %d\{i}";
+    }
+
+    @Benchmark
+    public String complexFormat() {
+        return FMT."%3s\{s} %10d\{i} %4S\{s} %04X\{i} %4S\{s} %04X\{i} %4S\{s} %04X\{i}";
+    }
+}
+


### PR DESCRIPTION
Interesting performance comparison with StringFormat benchmark:

```
> make test TEST="micro:java.lang.StringFormat"

Benchmark                               Mode  Cnt     Score    Error  Units
StringFormat.complexFormat              avgt   15  1543,311 ± 10,113  ns/op
StringFormat.stringFormat               avgt   15    52,746 ±  4,238  ns/op
StringFormat.stringIntFormat            avgt   15   135,289 ±  8,963  ns/op
StringFormat.widthStringFormat          avgt   15   191,535 ±  8,858  ns/op
StringFormat.widthStringIntFormat       avgt   15   263,939 ±  4,770  ns/op

> make test TEST="micro:java.lang.template.StringTemplateFMT"

Benchmark                               Mode  Cnt    Score     Error  Units
StringTemplateFMT.complexFormat         avgt   15   183,925 ±  1,114  ns/op
StringTemplateFMT.stringFormat          avgt   15     4,852 ±  0,020  ns/op
StringTemplateFMT.stringIntFormat       avgt   15     8,001 ±  0,047  ns/op
StringTemplateFMT.widthStringFormat     avgt   15     6,176 ±  0,010  ns/op
StringTemplateFMT.widthStringIntFormat  avgt   15    13,080 ±  0,371  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/amber pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/amber pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/amber/pull/86.diff">https://git.openjdk.org/amber/pull/86.diff</a>

</details>
